### PR TITLE
Optimize ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: ["1.22.5"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,8 +20,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          cache: false
-          go-version: ${{ matrix.go-version }}
+          go-version-file: ./go.mod
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           cache: false
           go-version: ${{ matrix.go-version }}


### PR DESCRIPTION
This pull request updates the actions version for the checkout and setup-go steps in the CI workflow. The checkout step is updated from v3 to v4, and the setup-go step is updated from v4 to v5.
Use go version in go.mod for ci.
Remove disable of go cache